### PR TITLE
Fix: SenWGPG

### DIFF
--- a/nodes.json
+++ b/nodes.json
@@ -6868,11 +6868,11 @@
     "Strasse": "Oranienstraße 106",
     "PLZ": "10969",
     "Ort": "Berlin",
-    "EMail": "poststelle@lageso.berlin.de",
+    "EMail": "post@senwgpg.berlin.de",
     "Tel": "(030) 9028-0",
     "Fax": "(030) 9028-3102",
     "Ebene": "Land",
-    "Abkuerzung": "SfWGPuG"
+    "Abkuerzung": "SenWGPG"
   }
 },{
   "_id": {


### PR DESCRIPTION
Die gebräuchlichere Abkürzung eingefügt, Mailadresse war wohl ein copy-paste-Fehler